### PR TITLE
chore!: remove commit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
 # Gh actions
 
-- `gh ac commit` - get the most recent workflow for current repo. Run `git commit`, `git push`. Then check repo workflow runs every 5s till a new workflow is started. Display workflow URL to user
-  <!-- - `gh ac commit -m` (TODO) - pass the commit message with the command, by passing the need for `git commit` -->
-
-  - `gh ac commit -a` - add all unstaged commits before making commit
-
 - `gh ac force` - get the most recent workflow for current repo. Perform a `git push --force` on the current branch. Then check repo workflow runs every 5s till a new workflow is started. Display workflow URL to user
-- `gh ac <commit|force> -w <WORKFLOW_NAME>` - specify the workflow name to search for. This is not case sensitive.
+- `gh ac <push|force> -w <WORKFLOW_NAME>` - specify the workflow name to search for. This is not case sensitive.
   - if there are currently staged changes, warn user before proceeding
 - `gh ac config --hostname` to get a custom hostname (for Github enterprise)
 - `gh ac <command> -v` - configure logging level. More time the flag is specified, the more granular the logging

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,39 +1,7 @@
 use anyhow::{anyhow, Result};
-use dialoguer::Editor;
 use git2::Repository;
 use log::debug;
-use std::io::Error;
-use std::ops::Deref;
 use std::process::Command;
-
-/// performs `git commit`
-/// * `message` - commit message to use. If None, will prompt user to enter a commit message
-///
-/// returns the commit message in the Option if successfully committed. Will return None if user did not enter a commit message, or did not save
-pub fn commit<'a>(message: &Option<String>) -> Result<Option<String>> {
-    let commit_msg: Option<String> = match message {
-        Some(message) => Some(message.deref().to_string()),
-        None => Editor::new().edit("Enter a commit message").unwrap_or(None),
-    };
-
-    if commit_msg.is_none() || commit_msg.as_ref().unwrap() == "" {
-        return Ok(None);
-    }
-
-    return match Command::new("git")
-        .arg("commit")
-        .arg("-m")
-        .arg(&commit_msg.as_ref().unwrap())
-        .output()
-    {
-        Ok(output) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            println!("{}", stdout);
-            Ok(commit_msg)
-        }
-        Err(output) => Err(anyhow!("Error commiting changes: {}", output)),
-    };
-}
 
 /// git push
 pub fn push<'a>(force: bool) -> Result<()> {
@@ -73,15 +41,6 @@ pub fn check_staged_files() -> bool {
     } else {
         return true;
     }
-}
-
-/// `git add -A`
-///
-/// returns Some(error) if there was an error. None otherwise
-pub fn add_all() -> Option<Error> {
-    let err = Command::new("git").arg("add").arg("-A").spawn().err();
-    debug!("adding all git changes");
-    return err;
 }
 
 /// `git commit --amend --no-edit`

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use clap::{arg, command, ArgMatches, Command};
 use dialoguer::Confirm;
 use env_logger::Env;
 use git::check_unpushed_changes;
-use log::{debug, error, info};
+use log::{error, info};
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,6 @@ fn main() {
                 .global(true),
         )
         .subcommand(
-            Command::new("commit")
-                .about("commit the current")
-                .arg(arg!(-w --workflow <WORKFLOW_NAME> "name of the workflow to return"))
-                .arg(arg!(-a --all "add all unstaged changes before commiting")),
-        )
-        .subcommand(
             Command::new("push")
                 .about("push all unpushed commits")
                 .arg(arg!(-w --workflow <WORKFLOW_NAME> "name of the workflow to return")),
@@ -67,43 +61,6 @@ fn main() {
     let gh = Gh::new(&config.hostname.as_deref());
 
     match cli.subcommand() {
-        Some(("commit", args)) => {
-            let arg_workflow_name = args.get_one::<String>("workflow");
-            let arg_commit_all = args.get_one::<bool>("all");
-
-            if *arg_commit_all.unwrap_or(&false) {
-                match git::add_all() {
-                    Some(e) => panic!("{}", e),
-                    None => {}
-                }
-            } else if !git::check_staged_files() {
-                info!("no staged files, exiting");
-                return;
-            }
-
-            let selected_workflow_name = {
-                if arg_workflow_name.is_none() {
-                    gh.select_workflow_name()
-                } else {
-                    arg_workflow_name.clone().unwrap().to_string()
-                }
-            };
-            debug!("user selected workflow name: {}", selected_workflow_name);
-
-            let initial_workflow_run = gh.get_workflow_run_by_name(&selected_workflow_name);
-
-            let commit_msg = git::commit(&None).unwrap();
-
-            if commit_msg.is_none() {
-                info!("no commit message was entered, exiting");
-                return;
-            }
-            info!("commiting successful: {}", commit_msg.unwrap());
-
-            git::push(false).expect("failed to push");
-
-            gh.check_for_new_workflow_run_by_id(&initial_workflow_run.unwrap());
-        }
         Some(("push", args)) => {
             let arg_workflow_name = args.get_one::<String>("workflow");
             match check_unpushed_changes() {


### PR DESCRIPTION
User should use git cli to commit changes. ie `git commit`. We should
not try to reinvent the game here

BREAKING CHANGE: removed `commit` command
