### PR TITLE
feat: always push

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,4 @@
-use anyhow::{anyhow, Result};
-use git2::Repository;
+use anyhow::Result;
 use log::debug;
 use std::process::Command;
 
@@ -53,64 +52,4 @@ pub fn commit_amend_no_edit() -> Result<()> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     println!("{}", stdout);
     return Ok(());
-}
-
-/// check if there are unpushed commits
-pub fn check_unpushed_changes() -> Result<bool> {
-    // Open the repository in the current directory
-    let repo = match Repository::open(".") {
-        Ok(repo) => repo,
-        Err(e) => {
-            return Err(anyhow!("Unable to open repository: {}", e.to_string()));
-        }
-    };
-
-    // Get the current branch name
-    let branch = match repo.head() {
-        Ok(reference) => {
-            let shorthand = reference.shorthand();
-            let shorthand = shorthand.map(|m| m.to_owned());
-            if let Some(name) = shorthand {
-                name
-            } else {
-                return Err(anyhow!("Failed to get current branch name"));
-            }
-        }
-        Err(e) => {
-            return Err(anyhow!("Failed to get current branch: {}", e));
-        }
-    };
-
-    // Check if the branch is ahead of its upstream
-    let branch_obj = match repo.find_branch(branch.as_str(), git2::BranchType::Local) {
-        Ok(branch_obj) => branch_obj,
-        Err(e) => {
-            return Err(anyhow!("Failed to find branch '{}': {}", branch, e));
-        }
-    };
-
-    let upstream = match branch_obj.upstream() {
-        Ok(upstream) => upstream,
-        Err(_) => {
-            eprintln!("Branch '{}' has no upstream configured", branch);
-            return Err(anyhow!("Branch '{}' has no upstream configured", branch));
-        }
-    };
-
-    let ahead_behind = match repo.graph_ahead_behind(
-        branch_obj.get().target().unwrap(),
-        upstream.get().target().unwrap(),
-    ) {
-        Ok((ahead, behind)) => (ahead, behind),
-        Err(e) => {
-            eprintln!("Failed to get ahead/behind information: {}", e);
-            return Err(anyhow!("Failed to get ahead/behind information: {}", e));
-        }
-    };
-
-    if ahead_behind.0 > 0 {
-        return Ok(true);
-    } else {
-        return Ok(false);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,19 +71,6 @@ fn main() {
             let arg_workflow_name = args.get_one::<String>("workflow");
             let arg_print_url = args.get_one::<bool>("url").unwrap_or_else(|| &false);
 
-            // match check_unpushed_changes() {
-            // Ok(changed) => {
-            // if !changed {
-            // info!("No unpushed commits. Exiting");
-            // process::exit(0);
-            // }
-            // }
-            // Err(e) => {
-            // error!("Error checking unpushed changes: {}", e.to_string());
-            // process::exit(1);
-            // }
-            // }
-
             let selected_workflow_name = {
                 if arg_workflow_name.is_none() {
                     gh.select_workflow_name()

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use clap::ArgAction;
 use clap::{arg, command, Command};
 use dialoguer::Confirm;
 use env_logger::Env;
-use git::check_unpushed_changes;
 use log::{error, info};
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
@@ -72,18 +71,18 @@ fn main() {
             let arg_workflow_name = args.get_one::<String>("workflow");
             let arg_print_url = args.get_one::<bool>("url").unwrap_or_else(|| &false);
 
-            match check_unpushed_changes() {
-                Ok(changed) => {
-                    if !changed {
-                        info!("No unpushed commits. Exiting");
-                        process::exit(0);
-                    }
-                }
-                Err(e) => {
-                    error!("Error checking unpushed changes: {}", e.to_string());
-                    process::exit(1);
-                }
-            }
+            // match check_unpushed_changes() {
+            // Ok(changed) => {
+            // if !changed {
+            // info!("No unpushed commits. Exiting");
+            // process::exit(0);
+            // }
+            // }
+            // Err(e) => {
+            // error!("Error checking unpushed changes: {}", e.to_string());
+            // process::exit(1);
+            // }
+            // }
 
             let selected_workflow_name = {
                 if arg_workflow_name.is_none() {


### PR DESCRIPTION
Remove checking if there are unpushed changes when using `gh ac push`

This makes the implementation easier. And makes it possible to allow users to find workflow runs that are previously triggered using `git push`
