### PR TITLE
refactor: use clap derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gh-ac"
 version = "1.0.0"
-description = "fire off gh actions and get the url to the action"
+description = "fire off github actions and open the lastest action run in browser"
 author = "Shawn Yu"
 edition = "2021"
 # build = "build.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod gh;
 mod git;
-use std::{env, process};
+use std::process;
 
 use crate::gh::Gh;
-use clap::{arg, command, Args, Command, Subcommand};
-use clap::{ArgAction, Parser};
+use clap::Parser;
+use clap::{arg, command, Args, Subcommand};
 use dialoguer::Confirm;
 use env_logger::Env;
 use log::{error, info};
@@ -63,37 +63,6 @@ struct Config {
     hostname: Option<String>,
 }
 
-fn build_cli() -> Command {
-    return command!()
-        .arg(
-            arg!(-v --verbose "increase verbosity")
-                .action(ArgAction::Count)
-                .global(true),
-        )
-        .subcommand(
-            Command::new("push")
-                .about("push all unpushed commits")
-                .arg(arg!(-w --workflow <WORKFLOW_NAME> "name of the workflow to return"))
-                .arg(arg!(--url "print out the workflow url instead of opening it in browser")),
-        )
-        .subcommand(
-            Command::new("force")
-                .about("force push to trigger a new workflow run")
-                .arg(arg!(-w --workflow <WORKFLOW_NAME> "name of the workflow to return"))
-                .arg(
-                    arg!(--url "print out the workflow url instead of opening it in browser")
-                        .action(ArgAction::SetTrue),
-                ),
-        )
-        .subcommand(
-            Command::new("config")
-                .about("set configuration values")
-                .arg(
-                    arg!(--hostname <HOSTNAME> "github hostname. ie mycorp.github.com")
-                        .required(true),
-                ),
-        );
-}
 fn main() {
     // CLI config values
     let config: Config = confy::load("gh-ac", None).unwrap();
@@ -183,103 +152,6 @@ fn main() {
             };
             confy::store("gh-ac", None, config).unwrap();
             info!("config saved");
-        }
-    }
-
-    return;
-    let cli = build_cli().get_matches();
-
-    // let verbose_count = &cli.get_count("verbose");
-    // if verbose_count == &(1 as u8) {
-    // env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
-    // } else if verbose_count == &(2 as u8) {
-    // env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug")).init();
-    // } else if verbose_count > &(2 as u8) {
-    // env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug,trace")).init();
-    // } else {
-    // env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
-    // }
-
-    // CLI config values
-    let config: Config = confy::load("gh-ac", None).unwrap();
-    let gh = Gh::new(&config.hostname.as_deref());
-
-    match cli.subcommand() {
-        Some(("push", args)) => {
-            let arg_workflow_name = args.get_one::<String>("workflow");
-            let arg_print_url = args.get_one::<bool>("url").unwrap_or_else(|| &false);
-
-            let selected_workflow_name = {
-                if arg_workflow_name.is_none() {
-                    gh.select_workflow_name()
-                } else {
-                    arg_workflow_name.clone().unwrap().to_string()
-                }
-            };
-
-            let initial_workflow_run = gh
-                .get_workflow_run_by_name(&selected_workflow_name)
-                .unwrap();
-
-            match git::push(false) {
-                Ok(_) => {}
-                Err(e) => {
-                    error!("Failed to push changes: {}", e.to_string());
-                    process::exit(1);
-                }
-            }
-
-            gh.check_for_new_workflow_run_by_id(&initial_workflow_run, &arg_print_url)
-        }
-        Some(("force", args)) => {
-            let arg_workflow_name = args.get_one::<String>("workflow");
-            let arg_print_url = args.get_one::<bool>("url").unwrap_or_else(|| &false);
-
-            let selected_workflow_name = {
-                if arg_workflow_name.is_none() {
-                    gh.select_workflow_name()
-                } else {
-                    arg_workflow_name.clone().unwrap().trim().to_string()
-                }
-            };
-
-            if git::check_staged_files()
-                && !Confirm::new()
-                    .with_prompt("There are staged changes. Are you sure you want to force push?")
-                    .default(false)
-                    .interact()
-                    .unwrap()
-            {
-                {
-                    info!("Ok, aborting");
-                    return;
-                }
-            }
-
-            let initial_workflow_run = gh
-                .get_workflow_run_by_name(&selected_workflow_name)
-                .unwrap();
-
-            git::commit_amend_no_edit().unwrap();
-            git::push(true).expect("failed to push");
-
-            gh.check_for_new_workflow_run_by_id(&initial_workflow_run, arg_print_url)
-        }
-        Some(("config", args)) => {
-            let arg_hostname = args.get_one::<String>("hostname");
-            let config = Config {
-                hostname: arg_hostname.cloned(),
-            };
-            confy::store("gh-ac", None, config).unwrap();
-            info!("config saved");
-        }
-        _ => {
-            match Command::print_help(&mut build_cli()) {
-                Ok(_) => {}
-                Err(_) => {
-                    error!("Failed to print help");
-                }
-            };
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,15 @@ enum Commands {
     Push(PushArgs),
     /// force push to trigger new workflow run(s)
     Force(ForceArgs),
+    /// set configuration values
+    Config(ConfigArgs),
 }
 
 #[derive(Args)]
 struct PushArgs {
     /// case insensitive name of the workflow to look for
-    #[arg(short, long)]
-    workflow: Option<String>,
+    #[arg(short, long = "workflow")]
+    workflow_name: Option<String>,
     /// print out the workflow url instead of opening it in browser
     #[arg(long, action = clap::ArgAction::SetTrue)]
     url: Option<bool>,
@@ -41,11 +43,18 @@ struct PushArgs {
 #[derive(Args)]
 struct ForceArgs {
     /// case insensitive name of the workflow to look for
-    #[arg(short, long)]
-    workflow: Option<String>,
+    #[arg(short, long = "workflow")]
+    workflow_name: Option<String>,
     /// print out the workflow url instead of opening it in browser
     #[arg(long, action = clap::ArgAction::SetTrue)]
     url: Option<bool>,
+}
+
+#[derive(Args)]
+struct ConfigArgs {
+    /// github custom hostname
+    #[arg(long)]
+    hostname: String,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -86,21 +95,110 @@ fn build_cli() -> Command {
         );
 }
 fn main() {
+    // CLI config values
+    let config: Config = confy::load("gh-ac", None).unwrap();
+    let gh = Gh::new(&config.hostname.as_deref());
     let cli = Cli::parse();
-    return;
 
+    match cli.verbosity {
+        1 => {
+            env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+        }
+        2 => {
+            env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug")).init();
+        }
+        3 => {
+            env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug,trace"))
+                .init();
+        }
+        _ => {
+            env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+        }
+    }
+
+    match cli.command {
+        Commands::Push(args) => {
+            let selected_workflow_name = {
+                if args.workflow_name.is_none() {
+                    gh.select_workflow_name()
+                } else {
+                    args.workflow_name.clone().unwrap().to_string()
+                }
+            };
+
+            let initial_workflow_run = gh
+                .get_workflow_run_by_name(&selected_workflow_name)
+                .unwrap();
+
+            match git::push(false) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("Failed to push changes: {}", e.to_string());
+                    process::exit(1);
+                }
+            }
+
+            gh.check_for_new_workflow_run_by_id(
+                &initial_workflow_run,
+                &args.url.unwrap_or_else(|| false),
+            )
+        }
+        Commands::Force(args) => {
+            let selected_workflow_name = {
+                if args.workflow_name.is_none() {
+                    gh.select_workflow_name()
+                } else {
+                    args.workflow_name.unwrap().trim().to_string()
+                }
+            };
+
+            if git::check_staged_files()
+                && !Confirm::new()
+                    .with_prompt("There are staged changes. Are you sure you want to force push?")
+                    .default(false)
+                    .interact()
+                    .unwrap()
+            {
+                {
+                    info!("Ok, aborting");
+                    return;
+                }
+            }
+
+            let initial_workflow_run = gh
+                .get_workflow_run_by_name(&selected_workflow_name)
+                .unwrap();
+
+            git::commit_amend_no_edit().unwrap();
+            git::push(true).expect("failed to push");
+
+            gh.check_for_new_workflow_run_by_id(
+                &initial_workflow_run,
+                &args.url.unwrap_or_else(|| false),
+            )
+        }
+        Commands::Config(args) => {
+            let config = Config {
+                hostname: Some(args.hostname),
+            };
+            confy::store("gh-ac", None, config).unwrap();
+            info!("config saved");
+        }
+    }
+
+    return;
     let cli = build_cli().get_matches();
 
-    let verbose_count = &cli.get_count("verbose");
-    if verbose_count == &(1 as u8) {
-        env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
-    } else if verbose_count == &(2 as u8) {
-        env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug")).init();
-    } else if verbose_count > &(2 as u8) {
-        env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug,trace")).init();
-    } else {
-        env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
-    }
+    // let verbose_count = &cli.get_count("verbose");
+    // if verbose_count == &(1 as u8) {
+    // env_logger::Builder::from_env(Env::default().default_filter_or("warn")).init();
+    // } else if verbose_count == &(2 as u8) {
+    // env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug")).init();
+    // } else if verbose_count > &(2 as u8) {
+    // env_logger::Builder::from_env(Env::default().default_filter_or("warn,debug,trace")).init();
+    // } else {
+    // env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    // }
 
     // CLI config values
     let config: Config = confy::load("gh-ac", None).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,50 @@ mod git;
 use std::{env, process};
 
 use crate::gh::Gh;
-use clap::ArgAction;
-use clap::{arg, command, Command};
+use clap::{arg, command, Args, Command, Subcommand};
+use clap::{ArgAction, Parser};
 use dialoguer::Confirm;
 use env_logger::Env;
 use log::{error, info};
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
+    verbosity: u8,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// push all unpushed commits
+    Push(PushArgs),
+    /// force push to trigger new workflow run(s)
+    Force(ForceArgs),
+}
+
+#[derive(Args)]
+struct PushArgs {
+    /// case insensitive name of the workflow to look for
+    #[arg(short, long)]
+    workflow: Option<String>,
+    /// print out the workflow url instead of opening it in browser
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    url: Option<bool>,
+}
+
+#[derive(Args)]
+struct ForceArgs {
+    /// case insensitive name of the workflow to look for
+    #[arg(short, long)]
+    workflow: Option<String>,
+    /// print out the workflow url instead of opening it in browser
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    url: Option<bool>,
+}
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 struct Config {
@@ -49,6 +86,9 @@ fn build_cli() -> Command {
         );
 }
 fn main() {
+    let cli = Cli::parse();
+    return;
+
     let cli = build_cli().get_matches();
 
     let verbose_count = &cli.get_count("verbose");


### PR DESCRIPTION
The original reason to use clap builder was to allow completion. However that is not possible with this being a GH CLI extension. Using clap derive means a cleaner interface
